### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ PadConnectReceiver/
 
 ## License
 
-[GPL3](https://github.com/Ishan09811/PadConnect/blob/master/LICENSE) License
+[![GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://spdx.org/licenses/GPL-3.0-only.html)
 
 ---
 


### PR DESCRIPTION
* License: GPL-3.0-only https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/io.github.padconnect.yml
* this badge adds unambigious license badge with spdx license text
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html
* i have gone ahead and attempted simple fix https://github.com/Ishan09811/PadConnect/issues/1